### PR TITLE
Update eyelink.py

### DIFF
--- a/PyHipp/__init__.py
+++ b/PyHipp/__init__.py
@@ -10,8 +10,8 @@ from .helperfunctions import computeFFT, removeLineNoise
 from .aligning_objects import aligning_objects
 from .umaze import Umaze
 from .spiketrain import Spiketrain
-# from .eyelink import EDFSplit 
-# from .eyelink import Eyelink
+from .eyelink import EDFSplit 
+from .eyelink import Eyelink
 from .vmlfp import VMLFP
 from .vmhighpass import VMHighPass
 from .vmraw import VMRaw

--- a/PyHipp/aligning_objects.py
+++ b/PyHipp/aligning_objects.py
@@ -25,7 +25,7 @@ import pandas as pd
 import hickle as hkl
 import DataProcessingTools as DPT
 from .rplparallel import RPLParallel
-# from .eyelink import Eyelink
+from .eyelink import Eyelink
 from .unity import Unity
 
 

--- a/PyHipp/eyelink.py
+++ b/PyHipp/eyelink.py
@@ -1,4 +1,9 @@
-from pyedfread import edfread
+import warnings
+try:
+    from pyedfread import edfread
+except ImportError:
+    warnings.warn("Eyelink import failed. You won't be able to read edf files")
+    edfread = None
 import numpy as np
 import numpy.matlib
 import pandas as pd


### PR DESCRIPTION
This allows the import of the pyedfread to fail gracefully if, for whatever reason, the underlying edfiapi framework cannot be found. The code will issue a warning about not being able to read edf files, but the rest of the code will work as normal.